### PR TITLE
Fix: Replace deprecated np.object with object

### DIFF
--- a/bias-detection-explanability/fairness_and_explainability.ipynb
+++ b/bias-detection-explanability/fairness_and_explainability.ipynb
@@ -514,7 +514,7 @@
     "    result = df.copy()\n",
     "    encoders = {}\n",
     "    for column in result.columns:\n",
-    "        if result.dtypes[column] == np.object:\n",
+    "        if result.dtypes[column] == object:\n",
     "            encoders[column] = preprocessing.LabelEncoder()\n",
     "            result[column] = encoders[column].fit_transform(result[column].fillna(\"None\"))\n",
     "    return result, encoders\n",


### PR DESCRIPTION
## Issue
[#4827](https://github.com/aws/amazon-sagemaker-examples-community/issues/25)

## Description of changes
This pull request fixes the issue caused by the removal of `np.object` in NumPy 1.20+.  
The `number_encode_features()` function previously checked column data types using:

```python
if result.dtypes[column] == np.object:
```

Since np.object was deprecated in NumPy 1.20 and later removed, this caused an AttributeError.
To resolve this issue, np.object has been replaced with the built-in object type:

```python
if result.dtypes[column] == object:
```

This change is fully compatible with older versions of NumPy while preventing future compatibility issues.

## Testing
- [x] Verified that the script runs without errors in NumPy 1.20+.  
- [x] Confirmed that the change does not break compatibility with older NumPy versions.  
- [x] Ran unit tests to ensure proper functionality.  

## By submitting this pull request, I confirm that:
- [x] You can use, modify, copy, and redistribute this contribution under the terms of your choice.
- [x] This change fixes the linked issue and does not introduce new bugs.
- [x] The update maintains backward compatibility with previous versions.