### PR TITLE
Replaced invalid create training job link

### DIFF
--- a/training/built-in-frameworks/create_endpoint.ipynb
+++ b/training/built-in-frameworks/create_endpoint.ipynb
@@ -37,7 +37,7 @@
     "\n",
     "The pricing for setting up an endpoint can be found [here](https://aws.amazon.com/sagemaker/pricing/)\n",
     "\n",
-    "Like a [CreateTrainingJob](https://github.com/hsl89/amazon-sagemaker-examples/blob/sagemaker-fundamentals/sagemaker-fundamentals/create-training-job/create-training-job.ipynb), Amazon SageMaker interacts with your inference logic via a containerized enviornment. \n",
+    "Like a [CreateTrainingJob](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker/client/create_training_job.html), Amazon SageMaker interacts with your inference logic via a containerized enviornment. \n",
     "\n",
     "The following APIs are relavent:\n",
     "* [`CreateModel`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker.html#SageMaker.Client.create_model)\n",
@@ -78,8 +78,6 @@
    "metadata": {},
    "source": [
     "## Set up a service role for SageMaker\n",
-    "\n",
-    "Review [notebook on execution role](https://github.com/hsl89/amazon-sagemaker-examples/blob/execution-role/sagemaker-fundamentals/execution-role/execution-role.ipynb) for step-by-step instructions on how to create an IAM Role.\n",
     "\n",
     "The service role is intended to be assumed by the SageMaker service to procure resources in your AWS account on your behalf.\n",
     "\n",
@@ -139,7 +137,7 @@
    "source": [
     "## Build an inference image\n",
     "\n",
-    "You inference image must be a self-contained web server. When you run your inference container locally, it should listen on port 8080 and accept POST requests to the `/invocations` endpoint. The payload of the POST requests is the content of the data that you want your model to predict. Since the inference container is essentially a web server, you should expect it to look differently from the container we used for [`CreateTrainingJob`](https://github.com/hsl89/amazon-sagemaker-examples/blob/sagemaker-fundamentals/sagemaker-fundamentals/create-training-job/create-training-job.ipynb). \n",
+    "You inference image must be a self-contained web server. When you run your inference container locally, it should listen on port 8080 and accept POST requests to the `/invocations` endpoint. The payload of the POST requests is the content of the data that you want your model to predict. Since the inference container is essentially a web server, you should expect it to look differently from the container we used for [`CreateTrainingJob`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker/client/create_training_job.html). \n",
     "\n",
     "In this notebook, we use a minimal python stack to build our web server:\n",
     "![Request serving stack](stack.png)"
@@ -481,7 +479,7 @@
    "source": [
     "## Test your image\n",
     "\n",
-    "Like in the [notebook for CreateTrainingJob](https://github.com/hsl89/amazon-sagemaker-examples/blob/sagemaker-fundamentals/sagemaker-fundamentals/create-training-job/create-training-job.ipynb), we replicate the Amazon SageMaker hosting environment and test your image locally before serving in production. You are encouraged to read through the section on [Use Your Own Inference Code with Hosting Services](https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-inference-code.html) and think about how would you replicate SageMaker hosting environment before moving on. \n",
+    "Like in the [notebook for CreateTrainingJob](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker/client/create_training_job.html), we replicate the Amazon SageMaker hosting environment and test your image locally before serving in production. You are encouraged to read through the section on [Use Your Own Inference Code with Hosting Services](https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-inference-code.html) and think about how would you replicate SageMaker hosting environment before moving on. \n",
     "\n",
     "Like for `CreateTrainingJob`, SageMaker reserves `/opt/ml` directory in your image to inject ML-related info for `CreateEndpoint`. In particular, it downloads your trained model artifact and inject it in the directory `/opt/ml/model`. When calling `CreateEndpoint` you will need to tell SageMaker the S3 URI of your model artifact. SageMaker will use then pull the artifact and inject it into `/opt/ml/model`. This means when defining your own inference logic, you should load your trained model from `/opt/ml/model`. \n",
     "\n",
@@ -585,7 +583,7 @@
    "metadata": {},
    "source": [
     "## Push the image to ECR\n",
-    "Now you have tested your image, the next thing to do is to push it to your ECR so that SageMaker can download it. We have discussed this in the [previous notebook on `CreateTrainingJob`](https://github.com/hsl89/amazon-sagemaker-examples/blob/sagemaker-fundamentals/sagemaker-fundamentals/create-training-job/create-training-job.ipynb) in the section where we push the training image to ECR. "
+    "Now you have tested your image, the next thing to do is to push it to your ECR so that SageMaker can download it. We have discussed this in the [previous notebook on `CreateTrainingJob`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker/client/create_training_job.html) in the section where we push the training image to ECR. "
    ]
   },
   {


### PR DESCRIPTION
https://t.corp.amazon.com/V1887586838

Replaced instances of invalid GitHub repo to a new link - https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker/client/create_training_job.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
